### PR TITLE
Support SVG classes

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,31 +22,38 @@ function ElementClass(opts) {
   if (typeof this.el !== 'object') this.el = document.querySelector(this.el)
 }
 
-ElementClass.prototype.add = function(className) {
+ElementClass.prototype.add = function(newName) {
   var el = this.el
   if (!el) return
-  if (el.className === "") return el.className = className
-  var classes = el.className.split(' ')
-  if (indexOf(classes, className) > -1) return classes
-  classes.push(className)
-  el.className = classes.join(' ')
+  var className = getClass(el)
+  if (className === "") return el.setAttribute('class', newName)
+  var classes = className.split(' ')
+  if (indexOf(classes, newName) > -1) return classes
+  classes.push(newName)
+  el.setAttribute('class', classes.join(' '))
   return classes
 }
 
-ElementClass.prototype.remove = function(className) {
+ElementClass.prototype.remove = function(name) {
   var el = this.el
   if (!el) return
-  if (el.className === "") return
-  var classes = el.className.split(' ')
+  var className = getClass(el)
+  if (className === "") return []
+  var classes = className.split(' ')
   var idx = indexOf(classes, className)
   if (idx > -1) classes.splice(idx, 1)
-  el.className = classes.join(' ')
+  el.setAttribute('class', classes.join(' '))
   return classes
 }
 
+ElementClass.prototype.contains =
 ElementClass.prototype.has = function(className) {
   var el = this.el
   if (!el) return
-  var classes = el.className.split(' ')
+  var classes = getClass(el).split(' ')
   return indexOf(classes, className) > -1
+}
+
+function getClass(el) {
+  return el.getAttribute('class') || ''
 }

--- a/perf.js
+++ b/perf.js
@@ -1,0 +1,12 @@
+var elementClass = require('./')
+
+var div = document.createElement('div')
+document.body.appendChild(div)
+
+console.time('test')
+for(var i = 0;i < 1000000; i++) {
+  elementClass(div).add('foo')
+  elementClass(div).has('foo')
+  elementClass(div).remove('foo')
+}
+console.timeEnd('test')

--- a/test.js
+++ b/test.js
@@ -1,14 +1,28 @@
 var test = require('tape')
 var elementClass = require('./')
 
-test('adds and removes a class', function(t) {
+test('add/remove/has for a html class', function(t) {
   var div = document.createElement('div')
   document.body.appendChild(div)
+  t.ok(!elementClass(div).has('foo'), 'has no class at first')
   elementClass(div).add('foo')
   var el = document.querySelectorAll('.foo')
-  t.equal(el.length, 1)
+  t.equal(el.length, 1, 'add class')
+  t.ok(elementClass(div).has('foo'), 'has class now')
   elementClass(div).remove('foo')
   el = document.querySelectorAll('.foo')
-  t.equal(el.length, 0)
+  t.equal(el.length, 0, 'remove class')
+  t.end()
+})
+
+test('add/remove/has for a svg class', function (t) {
+  var svg = document.createElement('svg')
+  document.body.appendChild(svg)
+  t.ok(!elementClass(svg).has('bar'), 'has no class at first')
+  elementClass(svg).add('bar')
+  t.ok(elementClass(svg).has('bar'), 'has class now')
+  t.equal(svg.getAttribute('class'), 'bar', 'class exists')
+  elementClass(svg).remove('bar')
+  t.equal(svg.getAttribute('class'), '', 'remove class')
   t.end()
 })


### PR DESCRIPTION
Hey there,

this module doesn't work with SVG, because for svg elements the `className` property is not a string. However if you use `getAttribute('class')` it works in svg as well as in html. 

Since I wasn't sure if this would has a negative impact on the performance, I added a perf.js file as well. It runs in my chrome in about 3-4 seconds for both the `className` an the `getAttribute` version in my browser.

getAttribute('class') is not supported by IE7 compared to the className attribute, but I guess that's ok :)

Best,
Finn
